### PR TITLE
Add more wrappers

### DIFF
--- a/Sources/xlsxwriter/Chart_Series.swift
+++ b/Sources/xlsxwriter/Chart_Series.swift
@@ -195,7 +195,7 @@ public struct Series {
     -> Series
   {
     var line = lxw_chart_line(
-      color: Color.black.rawValue, none: (hide ? 1 : 0), width: width, dash_type: UInt8(dash_type),
+    color: Color.black.hex, none: (hide ? 1 : 0), width: width, dash_type: UInt8(dash_type),
       transparency: UInt8(transparency))
     chart_series_set_trendline_line(lxw_chart_series, &line)
     return self

--- a/Sources/xlsxwriter/Enumerations.swift
+++ b/Sources/xlsxwriter/Enumerations.swift
@@ -114,24 +114,6 @@ public enum PaperType: UInt8 {
   case German_Std_Fanfold  // 8 1/2 x 12 in
   case German_Legal_Fanfold  // 8 1/2 x 13 in
 }
-/// Predefined values for common colors.
-public enum Color: UInt32 {
-  case black = 0x1000000
-  case blue = 0x0000FF
-  case brown = 0x800000
-  case cyan = 0x00FFFF
-  case gray = 0x808080
-  case green = 0x008000
-  case lime = 0x00FF00
-  case magenta = 0xFF00FF
-  case navy = 0x000080
-  case orange = 0xFF6600
-  case purple = 0x800080
-  case red = 0xFF0000
-  case silver = 0xC0C0C0
-  case white = 0xFFFFFF
-  case yellow = 0xFFFF00
-}
 
 /// Available chart types.
 public enum Chart_type: UInt8 {

--- a/Sources/xlsxwriter/Format.swift
+++ b/Sources/xlsxwriter/Format.swift
@@ -82,18 +82,18 @@ public struct Format {
   }
   /// Set the color of the cell border.
   @discardableResult public func border(color: Color) -> Format {
-    format_set_border_color(lxw_format, color.rawValue)
+    format_set_border_color(lxw_format, color.hex)
     return self
   }
   /// Set the color of the font used in the cell.
   @discardableResult public func font(color: Color) -> Format {
-    format_set_font_color(lxw_format, color.rawValue)
+    format_set_font_color(lxw_format, color.hex)
     return self
   }
   /// Set the pattern background color for a cell.
   @discardableResult public func background(color: Color) -> Format {
     format_set_pattern(lxw_format, 1)
-    format_set_bg_color(lxw_format, color.rawValue)
+    format_set_bg_color(lxw_format, color.hex)
     return self
   }
   /// Set the rotation of the text in a cell.
@@ -106,4 +106,34 @@ public struct Format {
     format_set_font_size(lxw_format, size)
     return self
   }
+  /// Set the text wrap to cell. This is required which cell's text contains line break to show correctly.
+  @discardableResult public func setTextWrap() -> Format {
+      format_set_text_wrap(lxw_format)
+      return self
+  }
 }
+
+/// Structure for color which contains common colors.
+public struct Color {
+  public var hex: UInt32
+  public init(hex: UInt32) {
+      self.hex = hex
+  }
+  
+  public static var black: Self = Self(hex: 0x1000000)
+  public static var blue: Self = Self(hex: 0x0000FF)
+  public static var brown: Self = Self(hex: 0x800000)
+  public static var cyan: Self = Self(hex: 0x00FFFF)
+  public static var gray: Self = Self(hex: 0x808080)
+  public static var green: Self = Self(hex: 0x008000)
+  public static var lime: Self = Self(hex: 0x00FF00)
+  public static var magenta: Self = Self(hex: 0xFF00FF)
+  public static var navy: Self = Self(hex: 0x000080)
+  public static var orange: Self = Self(hex: 0xFF6600)
+  public static var purple: Self = Self(hex: 0x800080)
+  public static var red: Self = Self(hex: 0xFF0000)
+  public static var silver: Self = Self(hex: 0xC0C0C0)
+  public static var white: Self = Self(hex: 0xFFFFFF)
+  public static var yellow: Self = Self(hex: 0xFFFF00)
+}
+

--- a/Sources/xlsxwriter/Worksheet.swift
+++ b/Sources/xlsxwriter/Worksheet.swift
@@ -147,6 +147,13 @@ public struct Worksheet {
     _ = worksheet_set_column(lxw_worksheet, first, last, width, f)
     return self
   }
+  /// Set the properties for a row of cells
+  @discardableResult public func row(_ row: UInt32, height: Double, format: Format? = nil) -> Worksheet
+  {
+    let f = format?.lxw_format
+    _ = worksheet_set_row(lxw_worksheet, row, height, f)
+    return self
+  }
   /// Set the properties for one or more columns of cells.
   @discardableResult public func hide_columns(_ col: Int, width: Double = 8.43) -> Worksheet {
     let first = UInt16(col)

--- a/Sources/xlsxwriter/Worksheet.swift
+++ b/Sources/xlsxwriter/Worksheet.swift
@@ -165,7 +165,7 @@ public struct Worksheet {
   }
   /// Set the color of the worksheet tab.
   @discardableResult public func tab(color: Color) -> Worksheet {
-    worksheet_set_tab_color(lxw_worksheet, color.rawValue)
+    worksheet_set_tab_color(lxw_worksheet, color.hex)
     return self
   }
   /// Set the default row properties.


### PR DESCRIPTION
I made some wrappers for better formatting.

- Add 'row' method for 'Worksheet' so that users can adjust height of rows.
- Add 'setTextWrap' method for 'Format'. When I export xlsx files in iOS which contains text with line breaking, the line breaking isn't shown in MS Excel in Windows. After some googling, I find out this is because textWrap format is not set. So I added this.
- Change enumeration 'Color' into a structure so that users can set more rich colors.